### PR TITLE
Copying gitignore file from NESCent May 2014 workshop.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.Rproj.user
+R.Rproj
+.Rhistory
+.RData
+.Rapp.history
+*.Rout
+*.pyc
+*~
+.DS_Store
+.ipynb_checkpoints
+


### PR DESCRIPTION
You don't want R's output files accidentally in your repo. This is essentially a copy as of NESCent/2014-05-08-datacarpentry@b37cbc0bc99c79735046178c38f53d51b6730438.
