### PR TITLE
Add blank lines after markdown headings

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ instruction of lessons by Karen Cranston, Hilmar Lapp, Tracy Teal and Ethan Whit
 ## Data
 
 ### Biology
+
 Data is from the paper S. K. Morgan Ernest, Thomas J. Valone, and James H. Brown. 2009. Long-term monitoring and experimental manipulation of a Chihuahuan Desert ecosystem near Portal, Arizona, USA. Ecology 90:1708.
 
 http://esapubs.org/archive/ecol/E090/118/
@@ -23,11 +24,13 @@ Master_suction_trap_data_list_uncleaned.csv is a pre-cleaning version of a publi
 ### SQL
 
 ### R materials
+
 Original materials adapted from SWC Python lessons by Sarah Supp.
 John Blischak led the continued development of materials with contributions
 from Gavin Simpson, Tracy Teal, Greg Wilson, Diego Barneche, Stephen Turner and Karthik Ram. 
 
 ### Spreadsheet Best Practices
+
 Original materials adapted from [Practical Data Management for Bug Counters](http://practicaldatamanagement.wordpress.com/) by Christie Bahlai <br>
 Christie Bahlai and Aleksandra Pawlik led the continued development of materials with contributions
 from Jennifer Bryan, Alexander Duryee, Jeffrey Hollister,  Daisie Huang, Owen Jones, and Ben Marwick

--- a/cheatsheets/shell.md
+++ b/cheatsheets/shell.md
@@ -16,6 +16,7 @@ Based on the very detailed material at [http://software-carpentry.org/v5/novice/
 ##Commands and hints
 
 ### Navigating, creating and moving things
+
 Printing working directory:
 	
 	$ pwd


### PR DESCRIPTION
This makes the documents easier to read and allows text editors
to correctly handle the text under the headings.
