### PR TITLE
Add license file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,58 @@
+### Instructional Material
+
+All Data Carpentry instructional material is made available under
+the Creative Commons Attribution license. You are free:
+
+* to **Share**---to copy, distribute and transmit the work
+* to **Remix**---to adapt the work
+
+Under the following conditions:
+
+* **Attribution**---You must attribute the work using "Copyright (c)
+  Data Carpentry" (but not in any way that suggests that we
+  endorse you or your use of the work).  Where practical, you must
+  also include a hyperlink to http://datacarpentry.org.
+
+With the understanding that:
+
+* **Waiver**---Any of the above conditions can be waived if you get
+  permission from the copyright holder.
+* **Other Rights**---In no way are any of the following rights
+  affected by the license:
+    * Your fair dealing or fair use rights;
+    * The author's moral rights;
+    * Rights other persons may have either in the work itself or in
+      how the work is used, such as publicity or privacy rights.  *
+* **Notice**---For any reuse or distribution, you must make clear to
+  others the license terms of this work. The best way to do this is
+  with a link to
+  [http://creativecommons.org/licenses/by/3.0/](http://creativecommons.org/licenses/by/3.0/).
+
+For the full legal text of this license, please see
+[http://creativecommons.org/licenses/by/3.0/legalcode](http://creativecommons.org/licenses/by/3.0/legalcode).
+
+### Software
+
+Except where otherwise noted, the example programs and other software
+provided by Data Carpentry are made available under the
+[OSI](http://opensource.org)-approved
+[MIT license](http://opensource.org/licenses/mit-license.html).
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Adds a license file based on the SWC license file, which is CC-BY
for material plus MIT for associated software.

Fixes #22.
