### PR TITLE
Move SQL reference material to end of lesson

### DIFF
--- a/lessons/sql/sql.md
+++ b/lessons/sql/sql.md
@@ -17,38 +17,10 @@ Relational databases
 * Relational databases store data in tables with fields (columns) and records
   (rows)
 * Data in tables has types, just like in Python, and all values in a field have
-  the same type
+  the same type ([list of data types](#datatypes))
 * Queries let us look up data or make calculations based on columns
 * The queries are distinct from the data, so if we change the data we can just
   rerun the query
-
-Data types
----------------
-
-| Data type  | Description |
-| :------------- | :------------- |
-| CHARACTER(n)  | Character string. Fixed-length n  |
-| VARCHAR(n) or CHARACTER VARYING(n) |	Character string. Variable length. Maximum length n |
-| BINARY(n) |	Binary string. Fixed-length n |
-| BOOLEAN	| Stores TRUE or FALSE values |
-| VARBINARY(n) or BINARY VARYING(n) |	Binary string. Variable length. Maximum length n |
-| INTEGER(p) |	Integer numerical (no decimal). |
-| SMALLINT | 	Integer numerical (no decimal). |
-| INTEGER |	Integer numerical (no decimal). |
-| BIGINT |	Integer numerical (no decimal). |
-| DECIMAL(p,s) |	Exact numerical, precision p, scale s. |
-| NUMERIC(p,s) |	Exact numerical, precision p, scale s. (Same as DECIMAL) |
-| FLOAT(p) |	Approximate numerical, mantissa precision p. A floating number in base 10 exponential notation. |
-| REAL |	Approximate numerical |
-| FLOAT |	Approximate numerical |
-| DOUBLE PRECISION |	Approximate numerical |
-| DATE |	Stores year, month, and day values |
-| TIME |	Stores hour, minute, and second values |
-| TIMESTAMP |	Stores year, month, day, hour, minute, and second values |
-| INTERVAL |	Composed of a number of integer fields, representing a period of time, depending on the type of interval |
-| ARRAY |	A set-length and ordered collection of elements |
-| MULTISET | 	A variable-length and unordered collection of elements |
-| XML |	Stores XML data |
 
 
 Database Management Systems
@@ -58,7 +30,7 @@ There are a number of different database management systems for relational
 data. We're going to use SQLite today, but basically everything we teach you
 will apply to the other database systems as well (e.g., MySQL, PostgreSQL, MS
 Access, Filemaker Pro). The only things that will differ are the details of
-exactly how to import and export data.
+exactly how to import and export data and the [details of data types](#datatypediffs).
 
 
 The data
@@ -74,25 +46,6 @@ This is a real dataset that has been used in over 100 publications.  I've
 simplified it just a little bit for the workshop, but you can download the
 [full dataset](http://esapubs.org/archive/ecol/E090/118/) and work with it using
 exactly the same tools we'll learn about today.
-
-
-SQL Data Type Quick Reference
------------------------------
-
-Different databases offer different choices for the data type definition.
-
-The following table shows some of the common names of data types between the various database platforms:
-
-| Data type |	Access |	SQLServer |	Oracle | MySQL | PostgreSQL |
-| :------------- | :------------- | :---------------- | :----------------| :----------------| :---------------|
-| boolean	| Yes/No |	Bit |	Byte |	N/A	| Boolean |
-| integer	| Number (integer) | Int |	Number | Int / Integer	| Int / Integer |
-| float	| Number (single)	|Float / Real |	Number |	Float |	Numeric
-| currency | Currency |	Money |	N/A |	N/A	| Money |
-| string (fixed) | N/A | Char |	Char | Char |	Char |
-| string (variable)	| Text (<256) / Memo (65k+)	| Varchar |	Varchar / Varchar2 |	Varchar |	Varchar |
-| binary object	OLE Object Memo	Binary (fixed up to 8K) | Varbinary (<8K) | Image (<2GB)	Long | Raw	Blob | Text	Binary | Varbinary |
-
 
 
 Database Design
@@ -425,3 +378,50 @@ Q & A on Database Design (review if time)
      * Split into separate tables with one table per class of information
 	 * Needs an identifier in common between tables – shared column - to
        reconnect (foreign key).
+
+
+<a name="datatypes"></a> Data types
+-----------------------------------
+
+| Data type  | Description |
+| :------------- | :------------- |
+| CHARACTER(n)  | Character string. Fixed-length n  |
+| VARCHAR(n) or CHARACTER VARYING(n) |	Character string. Variable length. Maximum length n |
+| BINARY(n) |	Binary string. Fixed-length n |
+| BOOLEAN	| Stores TRUE or FALSE values |
+| VARBINARY(n) or BINARY VARYING(n) |	Binary string. Variable length. Maximum length n |
+| INTEGER(p) |	Integer numerical (no decimal). |
+| SMALLINT | 	Integer numerical (no decimal). |
+| INTEGER |	Integer numerical (no decimal). |
+| BIGINT |	Integer numerical (no decimal). |
+| DECIMAL(p,s) |	Exact numerical, precision p, scale s. |
+| NUMERIC(p,s) |	Exact numerical, precision p, scale s. (Same as DECIMAL) |
+| FLOAT(p) |	Approximate numerical, mantissa precision p. A floating number in base 10 exponential notation. |
+| REAL |	Approximate numerical |
+| FLOAT |	Approximate numerical |
+| DOUBLE PRECISION |	Approximate numerical |
+| DATE |	Stores year, month, and day values |
+| TIME |	Stores hour, minute, and second values |
+| TIMESTAMP |	Stores year, month, day, hour, minute, and second values |
+| INTERVAL |	Composed of a number of integer fields, representing a period of time, depending on the type of interval |
+| ARRAY |	A set-length and ordered collection of elements |
+| MULTISET | 	A variable-length and unordered collection of elements |
+| XML |	Stores XML data |
+
+
+<a name="datatypediffs"></a> SQL Data Type Quick Reference
+----------------------------------------------------------
+
+Different databases offer different choices for the data type definition.
+
+The following table shows some of the common names of data types between the various database platforms:
+
+| Data type |	Access |	SQLServer |	Oracle | MySQL | PostgreSQL |
+| :------------- | :------------- | :---------------- | :----------------| :----------------| :---------------|
+| boolean	| Yes/No |	Bit |	Byte |	N/A	| Boolean |
+| integer	| Number (integer) | Int |	Number | Int / Integer	| Int / Integer |
+| float	| Number (single)	|Float / Real |	Number |	Float |	Numeric
+| currency | Currency |	Money |	N/A |	N/A	| Money |
+| string (fixed) | N/A | Char |	Char | Char |	Char |
+| string (variable)	| Text (<256) / Memo (65k+)	| Varchar |	Varchar / Varchar2 |	Varchar |	Varchar |
+| binary object	OLE Object Memo	Binary (fixed up to 8K) | Varbinary (<8K) | Image (<2GB)	Long | Raw	Blob | Text	Binary | Varbinary |


### PR DESCRIPTION
The SQL reference material added in 56221b3c7bb is useful, but
shouldn't be a focus when delivering this lesson in workshops
since we are assuming complete novices and presenting this level
of detail up front would be too much.

This change moves the material to the end of the lesson and
provides hyperlinks to it in the main material to highlight its
existence and make it easy to jump to when viewing the material
online.
