### PR TITLE
List lesson repositories in the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,33 @@ This repository is the historical repository of Data Carpentry lessons. Each les
 
 DO NOT USE OR DEVELOP IN THIS REPOSITORY
 
+Individual lessons
+------------------
 
- 
+The repositories for individual lessons can be found here:
+
+- Ecology:
+  - [excel-ecology](https://github.com/datacarpentry/excel-ecology)
+  - [OpenRefine-ecology](https://github.com/datacarpentry/OpenRefine-ecology)
+  - [python-ecology](https://github.com/datacarpentry/python-ecology)
+  - [R-dplyr-ecology](https://github.com/datacarpentry/R-dplyr-ecology)
+  - [R-ecology](https://github.com/datacarpentry/R-ecology)
+  - [R-ggplot2-ecology](https://github.com/datacarpentry/R-ggplot2-ecology)
+  - [scripting-ecology](https://github.com/datacarpentry/scripting-ecology)
+  - [shell-ecology](https://github.com/datacarpentry/shell-ecology)
+  - [sql-ecology](https://github.com/datacarpentry/sql-ecology)
+- Genomics:
+  - [cloud-genomics](https://github.com/datacarpentry/cloud-genomics)
+  - [datadescription-genomics](https://github.com/datacarpentry/datadescription-genomics)
+  - [knowyourdata-genomics](https://github.com/datacarpentry/knowyourdata-genomics)
+  - [organization-genomics](https://github.com/datacarpentry/organization-genomics)
+  - [shell-genomics](https://github.com/datacarpentry/shell-genomics)
+  - [wrangling-genomics](https://github.com/datacarpentry/wrangling-genomics)
+  - [R-genomics](https://github.com/datacarpentry/R-genomics)
+- Miscellaneous:
+  - [R-tidy-data-LoR](https://github.com/datacarpentry/R-tidy-data-LoR)
+  - [rnaseq-data-analysis](https://github.com/datacarpentry/rnaseq-data-analysis)
+  - [textmining-socialsci](https://github.com/datacarpentry/textmining-socialsci)
+- Templates
+  - [workshop-template](https://github.com/datacarpentry/workshop-template)
+  - [lesson-template](https://github.com/datacarpentry/lesson-template)


### PR DESCRIPTION
Currently split into subject matter sections and sorted alphabetically within those. Should fix #143.